### PR TITLE
Constant not exact

### DIFF
--- a/src/FMI2.jl
+++ b/src/FMI2.jl
@@ -600,7 +600,7 @@ end
 function fmi2StringToDependencyKind(s::AbstractString)
     if s == "dependent"
         return fmi2DependencyKindDependent
-    elseif s == "exact"
+    elseif s == "constant"
         return fmi2DependencyKindConstant
     elseif s == "fixed"
         return fmi2DependencyKindFixed


### PR DESCRIPTION
According to the 2.0 standard dependenciesKind can be "dependent", "constant", "fixed", "tunable" or "discrete".