### PR TITLE
Implementation of `fmi2Unit` and `fmi2SimpleType`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/site/
 Manifest.toml
 
 # Custom
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/home/manuelbb/.julia/dev/FMICore"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/manuelbb/.julia/dev/FMICore"
+}


### PR DESCRIPTION
I wanted to try working with Units and these changes seem to allow for it :)
The pull request defines the and exports the mutable types `fmi2Unit` and `fmi2SimpleType` which were marked as ToDo.
It also implements `BaseUnit` and `DisplayUnit` according to spec, but does not export them.

Up for debate:
* Types of the fields are deduced from the specification and up for debate.
* `Base.show` for `BaseUnit` is modified to print a pretty Unicode String.
* I have defined `const SI_UNIT_STRINGS = ("kg", "m", "s", "A", "K", "mol", "cd", "rad")` for convenient looping, also in `FMIImport`.