### PR TITLE
Implement property methods for `fmi2SimpleType`

### DIFF
--- a/src/FMI2/ctype.jl
+++ b/src/FMI2/ctype.jl
@@ -437,7 +437,7 @@ end
 function Base.setproperty!(var::fmi2ScalarVariable, sym::Symbol, value)
     if sym ∈ (:Real, :Integer, :Boolean, :String, :Enumeration)
         old_prop = getproperty(var, sym)
-        @assert typeof(old_prop) == typeof(value) "Cannot set property $(Meta.quot(sym)) of fmi2ScalarVariable to a value with type $(typeof(value))."
+        @assert isnothing(old_prop) || typeof(old_prop) == typeof(value) "Cannot set property $(Meta.quot(sym)) of fmi2ScalarVariable to a value with type $(typeof(value))."
         Base.setfield!(var, :variable, value)
     else 
         return invoke(Base.setproperty!, Tuple{Any, Symbol, Any}, var, sym, value)

--- a/src/FMI2/ctype.jl
+++ b/src/FMI2/ctype.jl
@@ -384,8 +384,25 @@ mutable struct fmi2ScalarVariable
 end
 export fmi2ScalarVariable
 
-# overwrite `getproperty` to mimic existance of properties `Real`, `Integer`, `Boolean`, `String`, 'Enumeration'
+# overwrite `getproperty` and `hasproperty` to mimic existence of properties 
+# `Real`, `Integer`, `Boolean`, `String`, 'Enumeration'
+function Base.hasproperty(var::fmi2ScalarVariable, sym::Symbol)
+    if sym in (:Real, :Integer, :Boolean, :String, :Enumeration)
+        prop = getfield(var, :variable)
+        return (
+            (sym == :Real && prop isa fmi2ModelDescriptionReal) ||
+            (sym == :Integer && prop isa fmi2ModelDescriptionInteger) ||
+            (sym == :String && prop isa fmi2ModelDescriptionString) ||
+            (sym == :Boolean && prop isa fmi2ModelDescriptionBoolean) ||
+            (sym == :Enumeration && prop isa fmi2ModelDescriptionEnumeration)
+        )
+    end
+    return Base.invoke(Base.hasproperty, Tuple{Any, Symbol}, var, sym)
+end
+
 function Base.getproperty(var::fmi2ScalarVariable, sym::Symbol)
+    # TODO usually querying a non-existent property throws an error
+    # for fmi2SimpleType we also throw, but here we return `nothing`
     if sym == :Real 
         if !isa(var.variable, fmi2ModelDescriptionReal) 
             return nothing 
@@ -416,9 +433,11 @@ function Base.getproperty(var::fmi2ScalarVariable, sym::Symbol)
     end 
 end
 
-# overwrite `setproperty!` to mimic existance of properties `Real`, `Integer`, `Boolean`, `String`, 'Enumeration'
+# overwrite `setproperty!` to mimic existence of properties `Real`, `Integer`, `Boolean`, `String`, 'Enumeration'
 function Base.setproperty!(var::fmi2ScalarVariable, sym::Symbol, value)
     if sym ∈ (:Real, :Integer, :Boolean, :String, :Enumeration)
+        old_prop = getproperty(var, sym)
+        @assert typeof(old_prop) == typeof(value) "Cannot set property $(Meta.quot(sym)) of fmi2ScalarVariable to a value with type $(typeof(value))."
         Base.setfield!(var, :variable, value)
     else 
         return invoke(Base.setproperty!, Tuple{Any, Symbol, Any}, var, sym, value)
@@ -499,6 +518,14 @@ Helper structure for the attributes of an Enumeration fmi2SimpleType.
 """
 struct fmi2SimpleTypeAttributesEnumeration <: fmi2SimpleTypeAttributeStruct end
 
+const FMI2_SIMPLE_TYPE_ATTRIBUTE_STRUCT = Union{
+    fmi2SimpleTypeAttributesReal,
+    fmi2SimpleTypeAttributesInteger,
+    fmi2SimpleTypeAttributesString,
+    fmi2SimpleTypeAttributesBoolean,
+    fmi2SimpleTypeAttributesEnumeration,
+}
+
 """ 
 Source: FMISpec2.0.3[p.40]: 2.2.3 Definition of Types (TypeDefinitions)
 
@@ -508,27 +535,64 @@ mutable struct fmi2SimpleType
     # mandatory
     name::String
     # one of 
-    type::fmi2SimpleTypeAttributeStruct
+    type::FMI2_SIMPLE_TYPE_ATTRIBUTE_STRUCT
 
     # optional
     description::Union{String, Nothing}
 
-
     function fmi2SimpleType(
-        name::String, attr::fmi2SimpleTypeAttributeStruct, description::Union{String, Nothing}=nothing
+        name::String, attr::FMI2_SIMPLE_TYPE_ATTRIBUTE_STRUCT, description::Union{String, Nothing}=nothing
     )
         @assert !isempty(name) "Positional argument `name::String` must not be empty."
-        st = new()
-        st.name = name
-        st.type = attr
-        st.description = description
-
-        return st
+        return new(name, attr, description)
     end
+end
+export fmi2SimpleType
 
+# Overwrite property setters and getters:
+
+## helper: Return true if `sym in (`Real`, `Integer` ...)` and false otherwise
+function isSpecialSimpleTypeProp(sym::Symbol)
+    return sym in (:Real, :Integer, :Boolean, :String, :Enumeration)
 end
 
-export fmi2SimpleType
+function Base.hasproperty(simpleType::fmi2SimpleType, sym::Symbol)
+    if isSpecialSimpleTypeProp(sym)
+        prop = getfield(simpleType, :type)
+        return (
+            (sym == :Real && prop isa fmi2SimpleTypeAttributesReal) ||
+            (sym == :Integer && prop isa fmi2SimpleTypeAttributesInteger) ||
+            (sym == :String && prop isa fmi2SimpleTypeAttributesString) ||
+            (sym == :Boolean && prop isa fmi2SimpleTypeAttributesBoolean) ||
+            (sym == :Enumeration && prop isa fmi2SimpleTypeAttributesEnumeration)
+        )
+    else
+        return Base.invoke(Base.hasproperty, Tuple{Any, Symbol}, simpleType, sym)
+    end
+end
+
+function Base.getproperty(simpleType::fmi2SimpleType, sym::Symbol)
+    @assert hasproperty(simpleType, sym) "The fmi2SimpleType object does not have a property $(Meta.quot(sym))."
+
+    if isSpecialSimpleTypeProp(sym)
+        return getfield(simpleType, :type)
+    else
+        return getfield(simpleType, sym)
+    end
+end
+
+function Base.setproperty!(
+    simpleType::fmi2SimpleType, sym::Symbol, new_prop::T
+) where T
+
+    if isSpecialSimpleTypeProp(sym)
+        prop = getproperty(simpleType, sym) # does check for existence, too
+        @assert typeof(prop) == T "Cannot set property $(Meta.quot(sym)) with object of type $(T)."
+        return setfield!(simpleType, :type, new_prop)
+    else
+        return setfield!(simpleType, sym, new_prop)
+    end
+end
 
 """
 Source: FMISpec2.0.3[p.35]: 2.2.2 Definition of Units (UnitDefinitions)

--- a/test/FMI2/fmi2SimpleTypeTests.jl
+++ b/test/FMI2/fmi2SimpleTypeTests.jl
@@ -1,0 +1,69 @@
+module fmi2SimpleTypeTests
+# Tests concerning `fmi2SimpleType` and attribute structs (fmi2SimpleTypeAttributesReal, etc.)
+using FMICore
+using Test
+
+const FMIC = FMICore
+
+attr_dict = Dict(
+    :Real => FMIC.fmi2SimpleTypeAttributesReal,
+    :Integer => FMIC.fmi2SimpleTypeAttributesInteger,
+    :Boolean => FMIC.fmi2SimpleTypeAttributesBoolean,
+    :String => FMIC.fmi2SimpleTypeAttributesString,
+    :Enumeration => FMIC.fmi2SimpleTypeAttributesEnumeration,
+)
+
+for (attr_symb, attr_type) in attr_dict
+    attr_struct = attr_type()
+
+    # check if all attribute fields initialize to `nothing`
+    for fn in fieldnames(attr_type)
+        @test isnothing(getfield(attr_struct, fn))
+    end
+
+    type_obj = fmi2SimpleType("testType", attr_struct)
+    
+    # check initial values and defaults
+    @test type_obj.name == "testType"
+    @test isnothing(type_obj.description)
+     # mutability?
+    type_obj.name = "newName"
+    @test type_obj.name == "newName"
+    type_obj.description = "Some Description"
+    @test type_obj.description == "Some Description"
+
+    type_obj = fmi2SimpleType("testType", attr_struct, "Some Description")
+     # check initial values and defaults
+    @test type_obj.name == "testType"
+    @test type_obj.description == "Some Description"
+
+    # mutability?
+    type_obj.name = "newName"
+    @test type_obj.name == "newName"
+    type_obj.description = nothing
+    @test isnothing(type_obj.description)
+
+    # check special getters
+    @test getfield(type_obj, :type) == attr_struct
+    @test hasproperty(type_obj, attr_symb)
+    @test getproperty(type_obj, attr_symb) == attr_struct
+
+    # check special setters
+    for (other_symb, other_type) in attr_dict
+        other_struct = other_type()
+        if attr_symb == other_symb
+            setproperty!(type_obj, attr_symb, other_struct)
+            @test getproperty(type_obj, attr_symb) === other_struct
+        else
+            @test !hasproperty(type_obj, other_symb)
+            # property `other_symb` should not be present => throw error
+            @test_throws AssertionError getproperty(type_obj, other_symb)
+            # do not allow setting wrong property type (and changing it thereby!)
+            @test_throws AssertionError setproperty!(type_obj, attr_symb, other_struct)
+        end
+    end
+
+end
+end#module
+
+using .fmi2SimpleTypeTests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@
 using FMICore
 using Test
 
+include(joinpath(@__DIR__, "FMI2", "fmi2SimpleTypeTests.jl"))


### PR DESCRIPTION
In "src/FMI2/ctype.jl":
* `hasproperty`, `getproperty` and `setproperty!` for `fmi2SimpleType`.
 
Some tests are in "test/FMI2/fmi2SimpleTypeTests.jl"

In "src/FMI2/ctype.jl":
* `hasproperty` for `fmi2ScalarVariable`
* Also slightly modified `setproperty!` for `fmi2ScalarVariable`: Do not allow to change property types accidentally.