### PR TITLE
Performance

### DIFF
--- a/src/FMI2/struct.jl
+++ b/src/FMI2/struct.jl
@@ -262,6 +262,12 @@ mutable struct FMU2Component{F}
     E::Union{FMUJacobian, Nothing}
     F::Union{FMUJacobian, Nothing}
 
+    # performance
+    stepEnterEventMode::Array{fmi2Boolean}
+    terminateSimulation::Array{fmi2Boolean}
+    ptr_stepEnterEventMode::Ptr{fmi2Boolean}
+    ptr_terminateSimulation::Ptr{fmi2Boolean}
+
     # deprecated
     realValues::Dict
     senseFunc::Symbol
@@ -323,6 +329,10 @@ mutable struct FMU2Component{F}
         inst.jac_ẋy_x = zeros(fmi2Real, 0, 0)
         inst.jac_ẋy_u = zeros(fmi2Real, 0, 0)
 
+        inst.stepEnterEventMode = zeros(fmi2Boolean, 1)
+        inst.terminateSimulation= zeros(fmi2Boolean, 1)
+        inst.ptr_stepEnterEventMode = pointer(inst.stepEnterEventMode)
+        inst.ptr_terminateSimulation = pointer(inst.terminateSimulation)
         return inst
     end
 

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -8,6 +8,7 @@ mutable struct FMUJacobian{R, V}
     valid::Bool 
 
     ∂f_refs::AbstractArray{<:V}
+    ∂f_refsset::Set{<:V}
     ∂x_refs::AbstractArray{<:V}
 
     updateFct!
@@ -26,6 +27,7 @@ mutable struct FMUJacobian{R, V}
         inst.c = zeros(R, length(∂x_refs))
         inst.valid = false 
         inst.∂f_refs = ∂f_refs
+        inst.∂f_refsset = Set(∂f_refs)
         inst.∂x_refs = ∂x_refs
         inst.updateFct! = updateFct!
 


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/ThummeTo/FMIImport.jl/pull/97. It pre-allocates some values inside an the `FMU2Component` to reduce allocations. at runtime Additionally it adds  $\partial$ `f_refsset = Set(`$\partial$`f_refs)` to `FMU2Component` for fast lookups in `fmi2SetReal` in `FMIImport.jl`.