### PR TITLE
Fix: fmi2Real must always be Cdouble, not architecture-dependent

### DIFF
--- a/src/FMICore.jl
+++ b/src/FMICore.jl
@@ -5,13 +5,9 @@
 
 module FMICore
 
-# Check float size on system (32 or 64 bits)
-juliaArch = Sys.WORD_SIZE
-@assert (juliaArch == 64 || juliaArch == 32) "FMICore: Unknown Julia Architecture with $(juliaArch)-bit, must be 64- or 32-bit."
+# fmi2Real/fmi3Float64 is always a C `double` per the FMI spec (fmi2TypesPlatform.h),
+# regardless of the host Julia's pointer width -- 32-bit only affects pointer size, not `double`.
 Creal = Cdouble
-if juliaArch == 32
-    Creal = Cfloat
-end
 
 # abstract types for inheritance 
 abstract type fmiModelDescription end


### PR DESCRIPTION
## Summary
`Creal` (backing `fmi2Real`/`fmi3Float64`) was set to `Cfloat` whenever `Sys.WORD_SIZE == 32`. The FMI spec hardcodes `typedef double fmi2Real;` unconditionally in `fmi2TypesPlatform.h` -- there is no 32-bit variant. Julia's word size reflects pointer width (relevant for `fmi2Component` handles), not the width of a C `double`.

## Impact
Under 32-bit Julia, every real value (states, inputs, outputs, parameters, time) ends up typed `Float32` instead of `Float64`. This breaks FMU simulation entirely -- state/output buffers end up as `Vector{Float32}`, which nothing downstream in FMIBase/FMIImport expects, eventually surfacing as:
```
AssertionError: Wrong dispatched: `x` is `Vector{Float32}`.
    This is most likely because you tried differentiating (AD) a FMU.
```
even though no AD/sensitivity analysis is involved.

## Testing
Confirmed on Julia 1.12.7 (`i686-w64-mingw32`, via `juliaup add 1.12.7~x86`) against two independent real-world FMUs (steady-state, Dymola-exported) that previously failed on 32-bit and succeeded on 64-bit. After this fix, both produce results on 32-bit matching their 64-bit runs to within floating-point noise.

Note: this also happens to eliminate a `Method overwriting is not permitted during Module precompilation` warning/error for `fmi2SetContinuousStates` in FMIImport, since the duplicate-looking `AbstractArray{Float32}`/`AbstractArray{Float64}` method pair was itself a downstream symptom of this same architecture branch.

There is a related, independent 32-bit bug in FMIBase (`cRef::UInt64` should be `UInt`) that this fix uncovers next -- see [FMIBase.jl#70](https://github.com/ThummeTo/FMIBase.jl/pull/70).
